### PR TITLE
ci: implement ansible CI workflow

### DIFF
--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -1,0 +1,19 @@
+---
+name: CI - Ansible
+
+on:
+  pull_request:
+    branches: 
+    - main
+    paths:
+    - src/ansible/**
+
+jobs:
+  lint-ansible:
+    name: Validate Ansible
+    uses: TheLionsRain/reusable-workflows/.github/workflows/lint-ansible.yml@lint-ansible-v1.0.0
+    with:
+      RUNS_ON: ubuntu-24.04
+      PYTHON_VERSION: 3.13
+      YAMLLINT_CONFIG_PATH: .yamllint
+      ANSIBLE_PATH: src/ansible/


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow specifically for validating Ansible configurations. The workflow is triggered on pull requests targeting the `main` branch, limited to changes in the `src/ansible/` directory.

### New GitHub Actions Workflow:

* [`.github/workflows/ci-ansible.yml`](diffhunk://#diff-c16400728308e11b7780d0476d61c93c241ec0bb51ca02b7b1b69200a08fe15dR1-R19): Introduced a workflow named "CI - Ansible" that uses a reusable workflow to validate Ansible configurations. It runs on `ubuntu-24.04` with Python 3.13 and includes configurations for `yamllint` and the Ansible path.