### PR TITLE
feat: implement swarm ansible role

### DIFF
--- a/src/ansible/inventory.yaml
+++ b/src/ansible/inventory.yaml
@@ -1,0 +1,37 @@
+---
+all:
+  hosts:
+    muspelheim-001:
+      ansible_host: 10.0.5.11
+      ansible_ssh_private_key_file: ~/.ssh/muspelheim
+      ansible_user: michiel
+    muspelheim-002:
+      ansible_host: 10.0.5.12
+      ansible_ssh_private_key_file: ~/.ssh/muspelheim
+      ansible_user: michiel
+    muspelheim-003:
+      ansible_host: 10.0.5.13
+      ansible_ssh_private_key_file: ~/.ssh/muspelheim
+      ansible_user: michiel
+
+  children:
+    ubuntu:
+      hosts:
+        muspelheim-001:
+        muspelheim-002:
+        muspelheim-003:
+
+    muspelheim_cluster:
+      hosts:
+        muspelheim-001:
+        muspelheim-002:
+        muspelheim-003:
+
+    muspelheim_leader:
+      hosts:
+        muspelheim-001:
+
+    muspelheim_managers:
+      hosts:
+        muspelheim-002:
+        muspelheim-003:

--- a/src/ansible/roles/swarm/README.md
+++ b/src/ansible/roles/swarm/README.md
@@ -1,0 +1,36 @@
+# Swarm
+This role is used for preparing a machine to be used for Docker Swarm. It installs Docker and its dependencies, sets up the appropriate repository and GPG keys, and ensures the user can run Docker without sudo.
+
+## Requirements
+- The target system should be a Debian-based distribution (e.g., Ubuntu).
+- Python must be installed on the managed host.
+- This role assumes internet access to download Docker packages and keys.
+- Ansible community.general and ansible.builtin collections should be available.
+- The boto package is not required, but if you're deploying on cloud instances (e.g., EC2), ensure related modules and credentials are set up outside this role.
+
+## Role Variables
+| Variable               | Default/Required       | Description                                                                                                 |
+| ---------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `docker_architecture`  | Required               | The system architecture, usually `amd64` or `arm64`, used in the Docker apt repository configuration.       |
+| `ansible_user`         | Automatically provided | The user who will be added to the Docker group for non-root Docker usage.                                   |
+| `ansible_lsb.codename` | Automatically provided | Used to dynamically set the appropriate Ubuntu codename (e.g., `focal`, `jammy`) for the Docker apt source. |
+
+## Dependencies
+
+None explicitly, but ensure your environment satisfies the requirements mentioned above. If you're using this in combination with other roles (e.g., security hardening, firewall), ensure Docker ports (e.g., `2377`, `7946`, `4789`) are open.
+
+## Example Playbook
+```yaml
+- hosts: docker_nodes
+  become: true
+  vars:
+    docker_architecture: amd64
+  roles:
+    - role: swarms
+```
+
+## License
+BSD
+
+## Author Information
+Created and maintained by Michiel Van Herreweghe [MichielVanHerreweghe](https://github.com/MichielVanHerreweghe). For issues or contributions, please visit the repository or contact via GitHub.

--- a/src/ansible/roles/swarm/tasks/install-dependencies.yml
+++ b/src/ansible/roles/swarm/tasks/install-dependencies.yml
@@ -1,0 +1,12 @@
+---
+- name: Install dependencies
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - python3-docker
+      - python3-kubernetes
+      - python3-jsondiff
+    state: present
+    update_cache: true
+  become: true

--- a/src/ansible/roles/swarm/tasks/install-docker.yml
+++ b/src/ansible/roles/swarm/tasks/install-docker.yml
@@ -1,0 +1,41 @@
+---
+- name: Download Docker signing key
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+  become: true
+
+- name: Add Docker apt repository
+  ansible.builtin.apt_repository:
+    repo: >
+      deb [arch={{ docker_architecture }} signed-by=/etc/apt/keyrings/docker.asc]
+      https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable
+    filename: docker
+    state: present
+  become: true
+
+- name: Install Docker
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true
+  become: true
+
+- name: Create Docker group
+  ansible.builtin.group:
+    name: docker
+    state: present
+  become: true
+
+- name: Add user to Docker group
+  ansible.builtin.user:
+    name: "{{ ansible_user }}"
+    groups: docker
+    append: true
+  become: true

--- a/src/ansible/roles/swarm/tasks/main.yml
+++ b/src/ansible/roles/swarm/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Install Docker
+  ansible.builtin.include_tasks: install-docker.yml


### PR DESCRIPTION
This pull request introduces a new Ansible role for setting up Docker Swarm on Debian-based systems. The changes include defining an inventory for managing hosts, creating tasks to install dependencies and Docker, and providing documentation for the new role.

### Inventory Setup:
* Added a new inventory file `src/ansible/inventory.yaml` to define hosts and groups for the Muspelheim cluster, including leaders and managers.

### Role Documentation:
* Created `src/ansible/roles/swarm/README.md` to document the purpose, requirements, variables, dependencies, and usage of the new Swarm role.

### Task Definitions:
* Added `src/ansible/roles/swarm/tasks/install-dependencies.yml` to install required dependencies such as `ca-certificates`, `curl`, and Python libraries for Docker and Kubernetes.
* Added `src/ansible/roles/swarm/tasks/install-docker.yml` to handle Docker installation, including downloading the signing key, adding the apt repository, installing Docker, and configuring user permissions.

### Task Orchestration:
* Updated `src/ansible/roles/swarm/tasks/main.yml` to ensure the required directory exists and include the Docker installation tasks.