### PR TITLE
feat: implement swarm_leader ansible role

### DIFF
--- a/src/ansible/roles/swarm_leader/README.md
+++ b/src/ansible/roles/swarm_leader/README.md
@@ -1,0 +1,30 @@
+# Swarm Leader
+This role initializes a Docker Swarm on a leader node. It ensures Docker Swarm is active and, if not, initiates it using the host's default IPv4 address. The role is typically used as the first step in setting up a Docker Swarm cluster, before adding worker nodes.
+
+## Requirements
+- Docker must be installed and accessible on the target system (e.g., via the swarm role).
+- The target system must have internet access and a valid IP address assigned to the default interface.
+- This role assumes you're using Ansible with elevated privileges (become: true).
+- Ansible ansible.builtin collection must be available.
+
+## Role Variables
+| Variable          | Default              | Description                                                                        |
+| ----------------- | -------------------- | ---------------------------------------------------------------------------------- |
+| `services_folder` | `/opt/docker/stacks` | Directory on the leader node intended to store or mount service stack definitions. |
+
+## Dependencies
+This role assumes Docker is already installed. You should run this role after the `swarm` role to ensure the system is Docker-ready.
+
+## Example Playbook
+```yaml
+- hosts: swarm_leader
+  become: true
+  roles:
+    - role: swarm.leader
+```
+
+## License
+BSD
+
+## Author Information
+Created and maintained by Michiel Van Herreweghe MichielVanHerreweghe. For issues or contributions, please visit the repository or contact via GitHub.

--- a/src/ansible/roles/swarm_leader/defaults/main.yml
+++ b/src/ansible/roles/swarm_leader/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+services_folder: "/opt/docker/stacks"

--- a/src/ansible/roles/swarm_leader/tasks/initialize.yml
+++ b/src/ansible/roles/swarm_leader/tasks/initialize.yml
@@ -1,0 +1,5 @@
+---
+- name: Initialize Docker Swarm
+  community.docker.docker_swarm:
+    state: present
+    advertise_addr: "{{ ansible_host }}"

--- a/src/ansible/roles/swarm_leader/tasks/main.yml
+++ b/src/ansible/roles/swarm_leader/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Initialize Docker Swarm
+  ansible.builtin.include_tasks: initialize.yml


### PR DESCRIPTION
This pull request introduces a new Ansible role, `swarm_leader`, which is responsible for initializing a Docker Swarm on a leader node. The role ensures that Docker Swarm is active and properly configured, making it a foundational step in setting up a Docker Swarm cluster. Below are the most important changes:

### New Role Documentation:
* Added a `README.md` file for the `swarm_leader` role, detailing its purpose, requirements, variables, dependencies, and usage examples. This includes a description of the `services_folder` variable and a sample playbook.

### Role Variables:
* Defined a default variable `services_folder` in `defaults/main.yml`, which specifies the directory for storing or mounting service stack definitions (`/opt/docker/stacks`).

### Tasks for Docker Swarm Initialization:
* Added a task file `tasks/initialize.yml` to initialize Docker Swarm using the `community.docker.docker_swarm` module. It sets the swarm state to `present` and advertises the host's IP address.
* Updated `tasks/main.yml` to include the `initialize.yml` task, ensuring the Docker Swarm initialization logic is executed.