### PR TITLE
feat: implement swarm_services ansible role

### DIFF
--- a/src/ansible/roles/swarm_services/README.md
+++ b/src/ansible/roles/swarm_services/README.md
@@ -1,0 +1,48 @@
+# Swarm Services
+This role is responsible for deploying custom Docker Swarm services using Docker Stack. It sets up a target directory for service definitions, renders docker-compose templates, and deploys them to the Swarm manager node.
+
+## Requirements
+- Docker and Docker Swarm must be installed and initialized on the target system.
+- This role assumes you have defined service-specific Compose templates and relevant environment variables.
+- Collections required: ansible.builtin, community.docker.
+- Internet access is typically required for pulling container images.
+
+## Role Variables
+| Variable          | Default              | Description                                                                              |
+| ----------------- | -------------------- | ---------------------------------------------------------------------------------------- |
+| `services_folder` | `/opt/docker/stacks` | The base directory where service definitions and `docker-compose` files will be created. |
+| `access_token`    | `#{ACCESS_TOKEN}#`   | Optional variable to inject secrets (e.g., API tokens) into service templates.           |
+
+## Dependencies
+This role assumes that the Docker Swarm environment is already initialized. You should run this after the `swarm` and `swarm.leader` roles.
+
+## Example Playbook
+```yaml
+- hosts: swarm_leader
+  become: true
+  vars:
+    access_token: "{{ lookup('env', 'MY_SERVICE_ACCESS_TOKEN') }}"
+  roles:
+    - role: swarm.services
+```
+
+## Templates
+### Github Actions Private Runner
+```jinja2
+services:
+  my-service:
+    image: myorg/myservice:latest
+    deploy:
+      replicas: 2
+    environment:
+      - ENV_VAR1=value1
+      - ACCESS_TOKEN={{ access_token }}
+    volumes:
+      - /data:/data
+```
+
+## License
+BSD
+
+## Author Information
+Created and maintained by Michiel Van Herreweghe MichielVanHerreweghe. For issues or contributions, please visit the repository or contact via GitHub.

--- a/src/ansible/roles/swarm_services/defaults/main.yml
+++ b/src/ansible/roles/swarm_services/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+services_folder: "/opt/docker/stacks"
+access_token: "#{ACCESS_TOKEN}#"

--- a/src/ansible/roles/swarm_services/tasks/main.yml
+++ b/src/ansible/roles/swarm_services/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Deploy Github Actions self-hosted runner
+  ansible.builtin.include_tasks: service-private-runners.yml

--- a/src/ansible/roles/swarm_services/tasks/service-private-runners.yml
+++ b/src/ansible/roles/swarm_services/tasks/service-private-runners.yml
@@ -1,0 +1,22 @@
+---
+- name: "Create services folder {{ services_folder }}"
+  ansible.builtin.file:
+    path: "{{ services_folder }}/private-runner"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: "Template the docker-compose file"
+  ansible.builtin.template:
+    src: private-runner-compose.yml.jinja2
+    dest: "{{ services_folder }}/private-runner/docker-compose.yml"
+    mode: '0644'
+  become: true
+
+- name: Deploy the private runner service
+  community.docker.docker_stack:
+    state: present
+    name: private-runners
+    compose:
+      - "{{ services_folder }}/private-runner/docker-compose.yml"
+  become: true

--- a/src/ansible/roles/swarm_services/templates/private-runner-compose.yml.jinja2
+++ b/src/ansible/roles/swarm_services/templates/private-runner-compose.yml.jinja2
@@ -1,0 +1,14 @@
+---
+services:
+  github-runner:
+    image: livingwooods/github-runner:1.1.0
+    deploy:
+      replicas: 2
+    environment:
+      - ORG_NAME=TheLionsRain
+      - ACCESS_TOKEN={{ access_token }}
+      - RUNNER_GROUP=muspelheim
+      - RUNNER_SCOPE=org
+      - EPHEMERAL=1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This pull request introduces a new Ansible role, `swarm_services`, for deploying Docker Swarm services using Docker Stack. Key changes include the addition of documentation, default variables, tasks for service deployment, and a template for a GitHub Actions self-hosted runner.

### Documentation and Role Overview:
* Added `README.md` to describe the purpose, requirements, variables, dependencies, and usage of the `swarm_services` role. It includes an example playbook and a sample Docker Compose template for a GitHub Actions private runner.

### Configuration and Defaults:
* Defined default variables in `defaults/main.yml`, including `services_folder` for service definitions and `access_token` for injecting secrets into templates.

### Task Implementation:
* Added `tasks/main.yml` to include the `service-private-runners.yml` task file for deploying a GitHub Actions self-hosted runner.
* Implemented `service-private-runners.yml` to:
  - Create the necessary directory for service definitions.
  - Render a Docker Compose template for the private runner.
  - Deploy the service using the `community.docker.docker_stack` module.

### Template for GitHub Actions Runner:
* Added `private-runner-compose.yml.jinja2` to define the Docker Compose configuration for a GitHub Actions self-hosted runner, including environment variables and volume mappings.