### PR TITLE
feat: implement swarm_manager ansible role

### DIFF
--- a/src/ansible/roles/swarm_manager/README.md
+++ b/src/ansible/roles/swarm_manager/README.md
@@ -1,0 +1,34 @@
+# Swarm Manager
+This role configures a node to join an existing Docker Swarm cluster as a manager. It uses a provided manager token and the IP address of an existing Swarm leader to securely join the cluster.
+
+## Requirements
+- Docker must be installed on the target node.
+- The Swarm must already be initialized on a leader node.
+- This node must be able to reach the Swarm leader over the network (default ports include 2377).
+- Collections required: ansible.builtin, community.docker.
+
+## Role Variables
+| Variable        | Default                   | Description                                                                                                     |
+| --------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `manager_token` | `#{SWARM_MANAGER_TOKEN}#` | The Swarm manager join token, typically retrieved from the leader node using `docker swarm join-token manager`. |
+| `leader_ip`     | *Required*                | The IP address of the existing Swarm leader node to join.                                                       |
+
+## Dependencies
+This role assumes that a Swarm leader is already initialized using the `swarm.leader` role, and that this manager node has Docker installed (e.g., via the `swarm` role).
+
+## Example Playbook
+```yaml
+- hosts: swarm_managers
+  become: true
+  vars:
+    leader_ip: 192.168.1.100
+    manager_token: "{{ lookup('env', 'SWARM_MANAGER_TOKEN') }}"
+  roles:
+    - role: swarm.manager
+```
+
+## License
+BSD
+
+## Author Information
+Created and maintained by Michiel Van Herreweghe [MichielVanHerreweghe](https://github.com/MichielVanHerreweghe). For issues or contributions, please visit the repository or contact via GitHub.

--- a/src/ansible/roles/swarm_manager/defaults/main.yml
+++ b/src/ansible/roles/swarm_manager/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+manager_token: "#{SWARM_MANAGER_TOKEN}#"

--- a/src/ansible/roles/swarm_manager/tasks/join.yml
+++ b/src/ansible/roles/swarm_manager/tasks/join.yml
@@ -1,0 +1,7 @@
+---
+- name: Join Docker Swarm
+  community.docker.docker_swarm:
+    state: join
+    join_token: "{{ manager_token }}"
+    remote_addrs: ["{{ leader_ip }}"]
+  become: true

--- a/src/ansible/roles/swarm_manager/tasks/main.yml
+++ b/src/ansible/roles/swarm_manager/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Join Docker Swarm
+  ansible.builtin.include_tasks: join.yml


### PR DESCRIPTION
This pull request introduces a new Ansible role, `swarm_manager`, to configure a node as a Docker Swarm manager. The role includes documentation, default variables, and tasks to join a Swarm cluster using a manager token and leader IP address.

### New Role: `swarm_manager`

**Documentation and Role Overview:**
* Added a `README.md` file that explains the purpose of the `swarm_manager` role, its requirements, variables, dependencies, and usage example.

**Default Variables:**
* Defined a default variable `manager_token` in `defaults/main.yml` to store the Swarm manager join token.

**Task Implementation:**
* Created a `join.yml` task file to handle the process of joining a Docker Swarm as a manager using the `community.docker.docker_swarm` module.
* Updated `tasks/main.yml` to include the `join.yml` task file.