### PR TITLE
feat: implement swarm_worker ansible role

### DIFF
--- a/src/ansible/roles/swarm_worker/README.md
+++ b/src/ansible/roles/swarm_worker/README.md
@@ -1,0 +1,34 @@
+# Swarm Worker
+This role configures a node to join an existing Docker Swarm cluster as a worker. It uses a provided worker join token and the IP address of an existing Swarm leader to securely join the cluster.
+
+## Requirements
+- Docker must be installed on the target node.
+- The Swarm must already be initialized on a leader node.
+- This node must be able to reach the Swarm leader over the network (default ports include 2377).
+- Collections required: ansible.builtin, community.docker.
+
+## Role Variables
+| Variable       | Default                  | Description                                                                                                   |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `worker_token` | `#{SWARM_WORKER_TOKEN}#` | The Swarm worker join token, typically retrieved from the leader node using `docker swarm join-token worker`. |
+| `leader_ip`    | *Required*               | The IP address of the existing Swarm leader node to join.                                                     |
+
+## Dependencies
+This role assumes that a Swarm leader is already initialized using the `swarm.leader` role, and that this worker node has Docker installed (e.g., via the `swarm` role).
+
+## Example Playbook
+```yaml
+- hosts: swarm_workers
+  become: true
+  vars:
+    leader_ip: 192.168.1.100
+    worker_token: "{{ lookup('env', 'SWARM_WORKER_TOKEN') }}"
+  roles:
+    - role: swarm.worker
+```
+
+## License
+BSD
+
+## Author Information
+Created and maintained by Michiel Van Herreweghe [MichielVanHerreweghe](https://github.com/MichielVanHerreweghe). For issues or contributions, please visit the repository or contact via GitHub.

--- a/src/ansible/roles/swarm_worker/defaults/main.yml
+++ b/src/ansible/roles/swarm_worker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+worker_token: "#{SWARM_WORKER_TOKEN}#"

--- a/src/ansible/roles/swarm_worker/tasks/join.yml
+++ b/src/ansible/roles/swarm_worker/tasks/join.yml
@@ -1,0 +1,7 @@
+---
+- name: Join Docker Swarm
+  community.docker.docker_swarm:
+    state: join
+    join_token: "{{ worker_token }}"
+    remote_addrs: ["{{ leader_ip }}"]
+  become: true

--- a/src/ansible/roles/swarm_worker/tasks/main.yml
+++ b/src/ansible/roles/swarm_worker/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Join Docker Swarm
+  ansible.builtin.include_tasks: join.yml


### PR DESCRIPTION
This pull request introduces a new Ansible role, `swarm_worker`, to configure a node as a Docker Swarm worker. The role includes documentation, default variables, and tasks to join a Swarm cluster using a worker join token and the leader node's IP address.

### New Ansible Role: `swarm_worker`

#### Documentation:
* [`src/ansible/roles/swarm_worker/README.md`](diffhunk://#diff-d1406a112e7f06fc16af5e543e2c0655f13de966fd50f21d1e45eee646a7949dR1-R34): Added a comprehensive README detailing the role's purpose, requirements, variables, dependencies, and usage example.

#### Role Variables:
* [`src/ansible/roles/swarm_worker/defaults/main.yml`](diffhunk://#diff-534b37a8315ac861f9a721a90fcbd1fa7f3dad7ec08f6fa6e7d5c970d55bb065R1-R2): Defined the `worker_token` variable with a placeholder value (`#{SWARM_WORKER_TOKEN}#`).

#### Tasks:
* [`src/ansible/roles/swarm_worker/tasks/join.yml`](diffhunk://#diff-a2effc06b3f277d4a782489c9b54c627855b8e0fc3306f2162a16c3b2272f7dbR1-R7): Added a task to join the Docker Swarm cluster using the `community.docker.docker_swarm` module with the provided `worker_token` and `leader_ip`.
* [`src/ansible/roles/swarm_worker/tasks/main.yml`](diffhunk://#diff-e822a509e631b48d473de59e9a4a3a3fb5833a4ee4d7ea6ceff817c5d528739bR1-R3): Included the `join.yml` task file to organize the role's functionality.