### PR TITLE
feat: implement swarm ansible playbooks

### DIFF
--- a/src/ansible/playbooks/swarm_deploy-services.yml
+++ b/src/ansible/playbooks/swarm_deploy-services.yml
@@ -1,0 +1,5 @@
+---
+- name: Initialize Docker Swarm
+  hosts: muspelheim_leader
+  roles:
+    - swarm_services

--- a/src/ansible/playbooks/swarm_initialize.yml
+++ b/src/ansible/playbooks/swarm_initialize.yml
@@ -1,0 +1,6 @@
+---
+- name: Initialize Docker Swarm
+  hosts: muspelheim_leader
+  roles:
+    - swarm
+    - swarm_leader

--- a/src/ansible/playbooks/swarm_join.manager.yml
+++ b/src/ansible/playbooks/swarm_join.manager.yml
@@ -1,0 +1,6 @@
+---
+- name: Join Docker Swarm - Manager
+  hosts: muspelheim_managers
+  roles:
+    - swarm
+    - swarm_manager

--- a/src/ansible/playbooks/swarm_join.worker.yml
+++ b/src/ansible/playbooks/swarm_join.worker.yml
@@ -1,0 +1,6 @@
+---
+- name: Join Docker Swarm - Worker
+  hosts: muspelheim_workers
+  roles:
+    - swarm
+    - swarm_worker


### PR DESCRIPTION
This pull request introduces new Ansible playbooks to set up and manage a Docker Swarm cluster. The playbooks handle swarm initialization, manager node joining, worker node joining, and service deployment.

### New Ansible Playbooks for Docker Swarm:

* **Swarm Initialization**:
  - Added `src/ansible/playbooks/swarm_initialize.yml` to initialize the Docker Swarm on the leader node with roles for swarm setup and leader configuration.

* **Manager Node Joining**:
  - Added `src/ansible/playbooks/swarm_join.manager.yml` to allow manager nodes to join the Docker Swarm with roles for swarm setup and manager configuration.

* **Worker Node Joining**:
  - Added `src/ansible/playbooks/swarm_join.worker.yml` to allow worker nodes to join the Docker Swarm with roles for swarm setup and worker configuration.

* **Service Deployment**:
  - Added `src/ansible/playbooks/swarm_deploy-services.yml` to deploy services on the Docker Swarm cluster, targeting the leader node.