### PR TITLE
chore: add muspelheim cluster ansible group variables

### DIFF
--- a/src/ansible/group_vars/muspelheim_cluster.yaml
+++ b/src/ansible/group_vars/muspelheim_cluster.yaml
@@ -1,0 +1,3 @@
+---
+docker_architecture: amd64
+leader_ip: 10.0.5.11


### PR DESCRIPTION
This pull request introduces a new configuration file for the Muspelheim cluster. The file specifies the Docker architecture and the leader IP address.

Configuration changes:

* [`src/ansible/group_vars/muspelheim_cluster.yaml`](diffhunk://#diff-1700fd745735175cdfd7ebfd9aa5750bbb634418228991da790271f8f2099be2R1-R3): Added `docker_architecture` set to `amd64` and `leader_ip` set to `10.0.5.11`.