### PR TITLE
feat: implement kubernetes role

### DIFF
--- a/src/ansible/roles/kubernetes/tasks/install-dependencies.yml
+++ b/src/ansible/roles/kubernetes/tasks/install-dependencies.yml
@@ -1,0 +1,14 @@
+---
+- name: Install dependencies
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+      - python3-kubernetes
+      - python3-jsondiff
+    state: present
+    update_cache: true
+  become: true

--- a/src/ansible/roles/kubernetes/tasks/install-helm.yml
+++ b/src/ansible/roles/kubernetes/tasks/install-helm.yml
@@ -1,0 +1,53 @@
+---
+- name: Download Helm signing key (raw)
+  ansible.builtin.get_url:
+    url: https://baltocdn.com/helm/signing.asc
+    dest: /tmp/helm-signing.asc
+    mode: '0644'
+  when: not ansible_facts.files['/usr/share/keyrings/helm.gpg'] is defined
+
+- name: Convert Helm signing key to GPG format
+  ansible.builtin.command:
+    cmd: gpg --dearmor -o /usr/share/keyrings/helm.gpg /tmp/helm-signing.asc
+  args:
+    creates: /usr/share/keyrings/helm.gpg
+  become: true
+
+- name: Remove temporary raw Helm signing key
+  ansible.builtin.file:
+    path: /tmp/helm-signing.asc
+    state: absent
+
+- name: Ensure apt-transport-https is installed
+  ansible.builtin.apt:
+    name: apt-transport-https
+    state: present
+  become: true
+
+- name: Add Helm repository
+  ansible.builtin.shell: >
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg]
+    https://baltocdn.com/helm/stable/debian/ all main"
+    > /etc/apt/sources.list.d/helm-stable-debian.list
+  args:
+    creates: /etc/apt/sources.list.d/helm-stable-debian.list
+  become: true
+
+- name: Update package list
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+
+- name: Install Helm
+  ansible.builtin.apt:
+    name: helm
+    state: present
+  become: true
+
+- name: Create Helm directory
+  ansible.builtin.file:
+    path: /opt/kubernetes/helm
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+  become: true

--- a/src/ansible/roles/kubernetes/tasks/main.yml
+++ b/src/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install dependencies
+  ansible.builtin.include_tasks: install-dependencies.yml
+
+- name: Install Helm
+  ansible.builtin.include_tasks: install-helm.yml
+
+# - name: Install Azure CLI
+#   ansible.builtin.include_tasks: install-azurecli.yml


### PR DESCRIPTION
This pull request introduces tasks for installing dependencies and Helm in the Kubernetes Ansible role. It organizes these tasks into separate files and integrates them into the main task file for better modularity and maintainability.

### Dependency Installation:

* Added a task file `install-dependencies.yml` to install essential packages such as `apt-transport-https`, `ca-certificates`, `curl`, and Python libraries (`python3-kubernetes`, `python3-jsondiff`). This ensures the required dependencies are installed and up-to-date.

### Helm Installation:

* Created a task file `install-helm.yml` to handle the installation of Helm. This includes downloading and converting the signing key, adding the Helm repository, updating the package list, and installing Helm. A dedicated directory for Helm was also created at `/opt/kubernetes/helm`.

### Integration into Main Task File:

* Updated `main.yml` to include the newly created `install-dependencies.yml` and `install-helm.yml` files, ensuring these tasks are executed as part of the Kubernetes role.