### PR TITLE
feat: implement kubernetes_leader role

### DIFF
--- a/src/ansible/roles/kubernetes_leader/files/external-secrets/cloudflare-api-token-secret.yml
+++ b/src/ansible/roles/kubernetes_leader/files/external-secrets/cloudflare-api-token-secret.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: cloudflare-api-key-clustersecret
+spec:
+  externalSecretName: cloudflare-api-key-secret
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - cert-manager
+  refreshTime: 1h
+  externalSecretSpec:
+    secretStoreRef:
+      kind: ClusterSecretStore
+      name: azure-key-vault
+    refreshInterval: "1h"
+    target:
+      name: cloudflare-api-key
+      creationPolicy: Owner
+      template:
+        data:
+          api-token: "{{ .cloudflareapitoken }}"
+    data:
+    - secretKey: cloudflareapitoken
+      remoteRef:
+        key: cloudflare-api-token

--- a/src/ansible/roles/kubernetes_leader/tasks/deploy-arc.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/deploy-arc.yml
@@ -21,7 +21,7 @@
     AZURE_CONFIG_DIR: "/tmp/.azure"
   register: arc_connect_result
   changed_when: "'Connected' in arc_connect_result.stdout or 'already connected' in arc_connect_result.stdout"
- 
+
 - name: Get OIDC issuer URL from Azure Arc Kubernetes cluster
   ansible.builtin.command: >
     az connectedk8s show

--- a/src/ansible/roles/kubernetes_leader/tasks/deploy-arc.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/deploy-arc.yml
@@ -1,0 +1,58 @@
+---
+- name: Login to Azure using service principal
+  ansible.builtin.shell: |
+    az login --service-principal \
+      --username "{{ azure_client_id }}" \
+      --password "{{ azure_client_secret }}" \
+      --tenant "{{ azure_tenant_id }}"
+  environment:
+    AZURE_CONFIG_DIR: "/tmp/.azure"
+  register: azure_login_result
+  changed_when: false
+
+- name: Connect Kubernetes cluster to Azure Arc
+  ansible.builtin.shell: |
+    az connectedk8s connect \
+      --name "{{ azure_arc_cluster_name }}" \
+      --resource-group "{{ azure_arc_resource_group }}" \
+      --enable-oidc-issuer \
+      --enable-workload-identity
+  environment:
+    AZURE_CONFIG_DIR: "/tmp/.azure"
+  register: arc_connect_result
+  changed_when: "'Connected' in arc_connect_result.stdout or 'already connected' in arc_connect_result.stdout"
+ 
+- name: Get OIDC issuer URL from Azure Arc Kubernetes cluster
+  ansible.builtin.command: >
+    az connectedk8s show
+    --name "{{ azure_arc_cluster_name }}"
+    --resource-group "{{ azure_arc_resource_group }}"
+    --query "oidcIssuerProfile.issuerUrl"
+    --output tsv
+  register: oidc_issuer_query
+  changed_when: false
+
+- name: Set OIDC issuer fact
+  ansible.builtin.set_fact:
+    oidc_issuer: "{{ oidc_issuer_query.stdout }}"
+
+- name: Ensure kube-apiserver-arg exists in k3s config
+  ansible.builtin.lineinfile:
+    path: /etc/rancher/k3s/config.yaml
+    line: "kube-apiserver-arg:"
+    state: present
+    insertbefore: BOF
+  when: oidc_issuer is defined
+  become: true
+
+- name: Add OIDCrelated kube-apiserver args to k3s config
+  ansible.builtin.blockinfile:
+    path: /etc/rancher/k3s/config.yaml
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: OIDC CONFIG"
+    insertafter: '^kube-apiserver-arg:'
+    block: |
+      - "service-account-issuer={{ oidc_issuer }}"
+      - "service-account-max-token-expiration=24h"
+  when: oidc_issuer is defined
+  become: true
+  notify: Restart k3s

--- a/src/ansible/roles/kubernetes_leader/tasks/deploy-cilium.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/deploy-cilium.yml
@@ -27,22 +27,23 @@
     url: https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt
     return_content: true
   register: cilium_cli_version
-  when: not cilium_installed
+  # when: not cilium_installed
 
 - name: Determine CLI architecture
   ansible.builtin.set_fact:
     cli_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-  when: not cilium_installed
+  # when: not cilium_installed
 
 - name: Download Cilium CLI tarball and checksum
   ansible.builtin.get_url:
-    url: "https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version.content | trim }}/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
+    url: >-
+      https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version.content | trim }}/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}
     dest: "/tmp/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
     mode: '0644'
   loop:
     - ""
     - ".sha256sum"
-  when: not cilium_installed
+  # when: not cilium_installed
 
 - name: Verify downloaded Cilium CLI checksum
   ansible.builtin.command: sha256sum --check cilium-linux-{{ cli_arch }}.tar.gz.sha256sum

--- a/src/ansible/roles/kubernetes_leader/tasks/deploy-cilium.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/deploy-cilium.yml
@@ -27,23 +27,24 @@
     url: https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt
     return_content: true
   register: cilium_cli_version
-  # when: not cilium_installed
+  when: not cilium_installed
 
 - name: Determine CLI architecture
   ansible.builtin.set_fact:
     cli_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
-  # when: not cilium_installed
+  when: not cilium_installed
 
 - name: Download Cilium CLI tarball and checksum
   ansible.builtin.get_url:
-    url: >-
-      https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version.content | trim }}/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}
+    url: "https://github.com/cilium/cilium-cli/releases/download/\
+      {{ cilium_cli_version.content | trim }}/\
+      cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
     dest: "/tmp/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
     mode: '0644'
   loop:
     - ""
     - ".sha256sum"
-  # when: not cilium_installed
+  when: not cilium_installed
 
 - name: Verify downloaded Cilium CLI checksum
   ansible.builtin.command: sha256sum --check cilium-linux-{{ cli_arch }}.tar.gz.sha256sum

--- a/src/ansible/roles/kubernetes_leader/tasks/deploy-cilium.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/deploy-cilium.yml
@@ -1,0 +1,126 @@
+---
+- name: Create Cilium Helm values directory exists
+  ansible.builtin.file:
+    path: /opt/kubernetes/helm/cilium
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+  become: true
+
+- name: Template Cilium Helm values file
+  ansible.builtin.template:
+    src: cilium/values.yml.jinja2
+    dest: /opt/kubernetes/helm/cilium/values.yml
+    mode: '0644'
+
+- name: Check if Cilium Helm release exists
+  ansible.builtin.command: helm list --namespace kube-system --filter '^cilium$' --output json
+  register: helm_cilium_status
+  changed_when: false
+
+- name: Set fact if Cilium is already installed
+  ansible.builtin.set_fact:
+    cilium_installed: "{{ (helm_cilium_status.stdout | from_json) | length > 0 }}"
+
+- name: Fetch latest Cilium CLI version
+  ansible.builtin.uri:
+    url: https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt
+    return_content: true
+  register: cilium_cli_version
+  when: not cilium_installed
+
+- name: Determine CLI architecture
+  ansible.builtin.set_fact:
+    cli_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+  when: not cilium_installed
+
+- name: Download Cilium CLI tarball and checksum
+  ansible.builtin.get_url:
+    url: "https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_version.content | trim }}/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
+    dest: "/tmp/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
+    mode: '0644'
+  loop:
+    - ""
+    - ".sha256sum"
+  when: not cilium_installed
+
+- name: Verify downloaded Cilium CLI checksum
+  ansible.builtin.command: sha256sum --check cilium-linux-{{ cli_arch }}.tar.gz.sha256sum
+  args:
+    chdir: /tmp
+  register: sha256_check
+  changed_when: false
+  failed_when: "'OK' not in sha256_check.stdout"
+  when: not cilium_installed
+
+- name: Extract Cilium CLI binary
+  become: true
+  ansible.builtin.unarchive:
+    src: "/tmp/cilium-linux-{{ cli_arch }}.tar.gz"
+    dest: /usr/local/bin
+    remote_src: true
+    extra_opts: [--strip-components=0]
+  when: not cilium_installed
+
+- name: Clean up Cilium CLI tarball and checksum
+  ansible.builtin.file:
+    path: "/tmp/cilium-linux-{{ cli_arch }}.tar.gz{{ item }}"
+    state: absent
+  loop:
+    - ""
+    - ".sha256sum"
+  when: not cilium_installed
+
+- name: Install Cilium via CLI
+  ansible.builtin.command: >
+    cilium install
+    --version v1.17.3
+    --set kubeProxyReplacement=true
+    --set k8sServiceHost="{{ ansible_host }}"
+    --set k8sServicePort=6443
+    --set l2announcements.enabled=true
+    --set l2announcements.leaseDuration="3s"
+    --set l2announcements.leaseRenewDeadline="1s"
+    --set l2announcements.leaseRetryPeriod="500ms"
+    --set devices="{{ '{' + cilium_network_interfaces | join(',') + '}' }}"
+    --set externalIPs.enabled=true
+    --set operator.replicas=2
+  register: cilium_install_result
+  changed_when: "'already installed' not in cilium_install_result.stderr"
+  when: not cilium_installed
+
+- name: Wait for Cilium to be ready
+  ansible.builtin.wait_for:
+    timeout: 10
+  delegate_to: localhost
+  when: not cilium_installed
+
+- name: Ensure Cilium manifest directory exists
+  ansible.builtin.file:
+    path: /opt/kubernetes/manifests/cilium
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+  become: true
+
+- name: Template L2 announcement policy manifest
+  ansible.builtin.template:
+    src: cilium/l2-announcement-policy.yml.jinja2
+    dest: /opt/kubernetes/manifests/cilium/l2-announcement-policy.yml
+    mode: '0644'
+
+- name: Apply L2 announcement policy
+  kubernetes.core.k8s:
+    src: /opt/kubernetes/manifests/cilium/l2-announcement-policy.yml
+    state: present
+
+- name: Template Cilium IP pool manifest
+  ansible.builtin.template:
+    src: cilium/ippool.yml.jinja2
+    dest: /opt/kubernetes/manifests/cilium/ippool.yml
+    mode: '0644'
+
+- name: Apply Cilium IP pool manifest
+  kubernetes.core.k8s:
+    src: /opt/kubernetes/manifests/cilium/ippool.yml
+    state: present

--- a/src/ansible/roles/kubernetes_leader/tasks/deploy-externalsecrets.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/deploy-externalsecrets.yml
@@ -1,0 +1,59 @@
+---
+- name: Create External Secrets manifest directory
+  ansible.builtin.file:
+    path: /opt/kubernetes/manifests/external-secrets
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+  become: true
+
+- name: Add external-secrets Helm repository
+  kubernetes.core.helm_repository:
+    name: external-secrets
+    repo_url: "https://charts.external-secrets.io"
+
+- name: Deploy external-secrets Helm chart
+  kubernetes.core.helm:
+    name: external-secrets
+    chart_ref: external-secrets/external-secrets
+    release_namespace: external-secrets
+    create_namespace: true
+
+- name: Wait for external-secrets to be ready
+  ansible.builtin.wait_for:
+    timeout: 60
+  delegate_to: localhost
+  when: not cilium_installed
+
+- name: Template SecretStore Secret manifest
+  ansible.builtin.template:
+    src: external-secrets/secret-store-secret.yml.jinja2
+    dest: /opt/kubernetes/manifests/external-secrets/secret-store-secret.yml
+    mode: '0644'
+
+- name: Apply SecretStore Secret manifest
+  kubernetes.core.k8s:
+    src: /opt/kubernetes/manifests/external-secrets/secret-store-secret.yml
+    state: present
+
+- name: Template ClusterSecretStore manifest
+  ansible.builtin.template:
+    src: external-secrets/cluster-secret-store.yml.jinja2
+    dest: /opt/kubernetes/manifests/external-secrets/cluster-secret-store.yml
+    mode: '0644'
+
+- name: Apply ClusterSecretStore manifest
+  kubernetes.core.k8s:
+    src: /opt/kubernetes/manifests/external-secrets/cluster-secret-store.yml
+    state: present
+
+- name: Copy Cloudflare API token Secret manifest
+  ansible.builtin.copy:
+    src: files/external-secrets/cloudflare-api-token-secret.yml
+    dest: /opt/kubernetes/manifests/external-secrets/cloudflare-api-external-secret.yml
+    mode: '0644'
+
+- name: Apply Cloudflare API ClusterExternalSecret manifest
+  kubernetes.core.k8s:
+    src: /opt/kubernetes/manifests/external-secrets/cloudflare-api-external-secret.yml
+    state: present

--- a/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
+++ b/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
@@ -1,0 +1,57 @@
+---
+- name: Create K3S directory
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    recurse: true
+  become: true
+
+- name: Template the K3S config file
+  ansible.builtin.template:
+    src: k3s/config.yaml.jinja2
+    dest: /etc/rancher/k3s/config.yaml
+    mode: '0644'
+  become: true
+
+- name: Gather service facts
+  ansible.builtin.service_facts:
+
+- name: Check if k3s service is active
+  ansible.builtin.set_fact:
+    k3s_active: "{{ ansible_facts.services['k3s.service'].state == 'running' }}"
+  when: "'k3s.service' in ansible_facts.services"
+
+- name: Ensure get.k3s.io is downloaded
+  ansible.builtin.get_url:
+    url: https://get.k3s.io
+    dest: /tmp/get_k3s.sh
+    mode: '0755'
+  when: not k3s_active | default(false)
+
+- name: Run K3S installer script
+  ansible.builtin.shell: |
+    set -o pipefail
+    /tmp/get_k3s.sh server
+  args:
+    executable: /bin/bash
+    creates: /usr/local/bin/k3s
+  when: not k3s_active | default(false)
+  become: true
+
+- name: Create .kube directory
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/.kube"
+    state: directory
+    owner: "{{ ansible_user }}"
+    mode: '0755'
+
+- name: Copy K3S kubectl config
+  ansible.builtin.copy:
+    remote_src: true
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: "/home/{{ ansible_user }}/.kube/config"
+    owner: "{{ ansible_user }}"
+    mode: '0644'
+  become: true

--- a/src/ansible/roles/kubernetes_leader/tasks/main.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Install K3S
+  ansible.builtin.include_tasks: install-k3s.yaml
+
+- name: Create manifests folder
+  ansible.builtin.file:
+    path: /opt/kubernetes/manifests
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    recurse: true
+  become: true
+
+- name: Apply Gateway API CRDs
+  kubernetes.core.k8s:
+    src: https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+    state: present
+
+- name: Install Cilium
+  ansible.builtin.include_tasks: deploy-cilium.yml
+
+# - name: Deploy Azure Arc
+#   ansible.builtin.include_tasks: deploy-arc.yml
+
+- name: Deploy External Secrets
+  ansible.builtin.include_tasks: deploy-externalsecrets.yml

--- a/src/ansible/roles/kubernetes_leader/templates/cilium/ippool.yml.jinja2
+++ b/src/ansible/roles/kubernetes_leader/templates/cilium/ippool.yml.jinja2
@@ -1,0 +1,9 @@
+---
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: "loadbalancer-pool"
+spec:
+  blocks:
+  - start: "{{ loadbalancer_ippool_start_ip }}"
+    stop: "{{ loadbalancer_ippool_end_ip }}"

--- a/src/ansible/roles/kubernetes_leader/templates/cilium/l2-announcement-policy.yml.jinja2
+++ b/src/ansible/roles/kubernetes_leader/templates/cilium/l2-announcement-policy.yml.jinja2
@@ -1,0 +1,9 @@
+---
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: l2-announcement-policy
+spec:
+  externalIPs: true
+  loadBalancerIPs: true
+  interfaces: {{ cilium_network_interfaces | to_yaml }}

--- a/src/ansible/roles/kubernetes_leader/templates/cilium/values.yml.jinja2
+++ b/src/ansible/roles/kubernetes_leader/templates/cilium/values.yml.jinja2
@@ -1,0 +1,17 @@
+---
+ipam.mode: cluster-pool
+ipam.clusterPoolIPv4PodCIDR: 10.42.0.0/16
+kubeProxyReplacement: true
+k8sServiceHost: "{{ ansible_host }}"
+k8sServicePort: 6443 # Move to defaults
+envoy.securityContext.capabilities.keepCapNetBindService: true
+enable-endpoint-routes: true
+enable-pod-ent: true
+hubble.relay.enabled: true
+hubble.ui.enabled: true
+l2announcements.enabled: true
+l2announcements.leaseDuration: "3s"
+l2announcements.leaseRenewDeadline: "1s"
+l2announcements.leaseRetryPeriod: "500ms"
+externalIPs.enabled: true
+devices: devices: "{{ '{' + cilium_network_interfaces | join(',') + '}' }}"

--- a/src/ansible/roles/kubernetes_leader/templates/external-secrets/cluster-secret-store.yml.jinja2
+++ b/src/ansible/roles/kubernetes_leader/templates/external-secrets/cluster-secret-store.yml.jinja2
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: azure-key-vault
+spec:
+  provider:
+    azurekv:
+      authType: ServicePrincipal
+      vaultUrl: {{ keyvault_url }}
+      tenantId: {{ keyvault_tenant_id }}
+      authSecretRef:
+        clientId:
+          name: azure-key-vault-store
+          key: clientId
+          namespace: external-secrets
+        clientSecret:
+          name: azure-key-vault-store
+          key: clientSecret
+          namespace: external-secrets

--- a/src/ansible/roles/kubernetes_leader/templates/external-secrets/secret-store-secret.yml.jinja2
+++ b/src/ansible/roles/kubernetes_leader/templates/external-secrets/secret-store-secret.yml.jinja2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-key-vault-store
+  namespace: external-secrets
+type: Opaque
+stringData:
+  clientId: {{ external_secrets_client_id }}
+  clientSecret: {{ external_secrets_client_secret }}

--- a/src/ansible/roles/kubernetes_leader/templates/k3s/config.yaml.jinja2
+++ b/src/ansible/roles/kubernetes_leader/templates/k3s/config.yaml.jinja2
@@ -1,0 +1,5 @@
+write-kubeconfig-mode: 0644
+disable: {{ disabled_components | to_yaml }}
+tls-san: {{ tls_sans | to_yaml }}
+cluster-init: true
+flannel-backend: none


### PR DESCRIPTION
This pull request introduces significant changes to automate the deployment and configuration of a Kubernetes leader node using Ansible. Key additions include the installation and configuration of K3S, the setup of Cilium for networking, the deployment of Azure Arc integration, and the configuration of External Secrets for managing secrets. Below is a summary of the most important changes grouped by theme.

### Kubernetes Installation and Configuration
* Added tasks to install and configure K3S, including templating the K3S configuration file (`k3s/config.yaml.jinja2`) with parameters for TLS SANs, disabled components, and cluster initialization. (`[[1]](diffhunk://#diff-3b0e45f2d3eb69e77b26ccc558e06c7b5b43acb5f943330b27813272aec98f74R1-R57)`, `[[2]](diffhunk://#diff-72c44678ffd817fd1004a4d1ef98faebf7c79f3133c5bcb88dd3086ee50346beR1-R5)`)

### Networking with Cilium
* Automated the deployment of Cilium, including templating Helm values (`cilium/values.yml.jinja2`) and applying manifests for L2 announcement policies (`cilium/l2-announcement-policy.yml.jinja2`) and IP pools (`cilium/ippool.yml.jinja2`). (`[[1]](diffhunk://#diff-175368c207f65fc2ad7a0c53d2fb931b7b243f1a9628ac3c622a099bbb4f443fR1-R126)`, `[[2]](diffhunk://#diff-7dbbeed1f94b086b38d1c3a13fc6e9c6f804514c8156d1ba2d7198614e275d32R1-R17)`, `[[3]](diffhunk://#diff-d65aa897982950c815851aff8f5e8b0e6a1e9c23122da5f82687e2954dd45014R1-R9)`, `[[4]](diffhunk://#diff-96c4913b11c1c9495e88a1262e99dc0d9381653e62d7e9cb0991d6d653cbf87cR1-R9)`)

### Azure Arc Integration
* Added tasks to connect the Kubernetes cluster to Azure Arc, including logging in with a service principal, enabling OIDC, and configuring the K3S API server for OIDC issuer support. (`[src/ansible/roles/kubernetes_leader/tasks/deploy-arc.ymlR1-R58](diffhunk://#diff-1762e0d88dc5bc8b1cb29783879c59e124a314163da1a83955fc568998e91ae1R1-R58)`)

### External Secrets Management
* Deployed External Secrets using Helm, configured Azure Key Vault as a `ClusterSecretStore`, and added a `ClusterExternalSecret` for managing Cloudflare API tokens. (`[[1]](diffhunk://#diff-f82bfc4ff52a785f8fbd8ac2043dd802e8069f67693acaf04c01f024ec4a1158R1-R59)`, `[[2]](diffhunk://#diff-652d97598e530833844cd51b35107375f32c2541da6a23820dc38fb074bea602R1-R29)`, `[[3]](diffhunk://#diff-3972dc887be898e8c4fa4ee0761a8f48e69718a6524a87e8f209cda16b375f81R1-R20)`, `[[4]](diffhunk://#diff-efc1637287225fe3999fcdbea45cde01f45d90ac2633954ebd97f8d1e1f55e11R1-R10)`)

### General Enhancements
* Created a centralized directory structure for Kubernetes manifests and ensured proper permissions for all configuration and manifest files. (`[src/ansible/roles/kubernetes_leader/tasks/main.ymlR1-R27](diffhunk://#diff-d403f0dac15cc13cdd95d959456a15ff45653079710c46d4dac40bbbddedf6fbR1-R27)`)