### PR TITLE
feat: implement kubernetes cluster initialization playbook

### DIFF
--- a/src/ansible/playbooks/kubernetes_initialize.yml
+++ b/src/ansible/playbooks/kubernetes_initialize.yml
@@ -1,0 +1,6 @@
+---
+- name: Initialize K3S Cluster
+  hosts: k3s_leader
+  roles:
+    - kubernetes
+    - kubernetes_leader


### PR DESCRIPTION
This pull request introduces a new Ansible playbook for initializing a K3S Kubernetes cluster. The playbook defines a task to set up the cluster on the designated leader node.

Key change:

* [`src/ansible/playbooks/kubernetes_initialize.yml`](diffhunk://#diff-86f672f71517fbaaef73506073889b083d602b4b192bfe3bd377a0c4c57807d7R1-R6): Added a new playbook named `kubernetes_initialize.yml` to initialize a K3S cluster. It specifies the `k3s_leader` host group and includes the `kubernetes` and `kubernetes_leader` roles.