### PR TITLE
ci: implement lint workflow for workflows

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,19 @@
+---
+name: Lint - Workflows
+
+on:
+  pull_request:
+    branches: 
+    - main
+    paths:
+    - .github/worfklows/**
+
+jobs:
+  lint-yaml:
+    name: Validate YAML
+    uses: TheLionsRain/reusable-workflows/.github/workflows/lint-yaml.yml@lint-yaml-v1.0.0
+    with:
+      RUNS_ON: ubuntu-24.04
+      PYTHON_VERSION: 3.13
+      YAMLLINT_CONFIG_PATH: .yamllint
+      LINT_PATH: .github/workflows/


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to lint YAML files in the `.github/workflows/` directory. The workflow is triggered on pull requests targeting the `main` branch.

Key addition:

* [`.github/workflows/lint-workflows.yml`](diffhunk://#diff-20ce74f39298d8724bf08ab59184d84e7a21326dcaa25bd2b5c5e3493b0727e0R1-R19): Added a new workflow named "Lint - Workflows" that uses a reusable workflow to validate YAML files. It specifies configurations such as the runner OS (`ubuntu-24.04`), Python version (`3.13`), and paths for YAML linting (`.github/workflows/`).