### PR TITLE
fix: move access_token tokenization to group_vars

### DIFF
--- a/.github/workflows/cd-kubernetes-initialize.yml
+++ b/.github/workflows/cd-kubernetes-initialize.yml
@@ -25,5 +25,6 @@ jobs:
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}
       TOKENS: '{
-          "EXTERNAL_SECRETS_CLIENT_SECRET": "${{ secrets.EXTERNAL_SECRETS_CLIENT_SECRET }}"
+          "EXTERNAL_SECRETS_CLIENT_SECRET": "${{ secrets.EXTERNAL_SECRETS_CLIENT_SECRET }}",
+          "ACCESS_TOKEN": "${{ secrets.ACCESS_TOKEN }}"
         }'

--- a/src/ansible/inventories/group_vars/helheim_cluster.yml
+++ b/src/ansible/inventories/group_vars/helheim_cluster.yml
@@ -1,4 +1,6 @@
 ---
+github_env: helheim
+github_repo: TheLionsRain/homelab
 disabled_components:
 - "servicelb"
 - "traefik"
@@ -16,3 +18,4 @@ keyvault_url: "https://kv-homelab-helheim-ne.vault.azure.net/"
 keyvault_tenant_id: "5897482a-f0cc-4b2a-acea-6df9a4fe00b5"
 external_secrets_client_id: "09efc1fe-6ac9-4ada-8eb8-7d9d3c758c1c"
 external_secrets_client_secret: "#{EXTERNAL_SECRETS_CLIENT_SECRET}#"
+access_token: "#{ACCESS_TOKEN}#"

--- a/src/ansible/roles/kubernetes_leader/defaults/main.yml
+++ b/src/ansible/roles/kubernetes_leader/defaults/main.yml
@@ -1,4 +1,0 @@
----
-github_token: "#{PAT_TOKEN}#"
-github_env: helheim
-github_repo: TheLionsRain/homelab

--- a/src/ansible/roles/kubernetes_leader/tasks/install-githubcli.yml
+++ b/src/ansible/roles/kubernetes_leader/tasks/install-githubcli.yml
@@ -17,7 +17,10 @@
 
 - name: Add GitHub CLI apt repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch={{ dpkg_architecture }} signed-by=/etc/apt/keyrings/githubcli.gpg] https://cli.github.com/packages stable main"
+    repo: >
+      "deb [arch={{ dpkg_architecture }}
+      signed-by=/etc/apt/keyrings/githubcli.gpg]
+      https://cli.github.com/packages stable main"
     filename: githubcli
     state: present
   become: true

--- a/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
+++ b/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
@@ -46,6 +46,7 @@
     state: directory
     owner: "{{ ansible_user }}"
     mode: '0755'
+  when: not k3s_active | default(false)
 
 - name: Copy K3S kubectl config
   ansible.builtin.copy:
@@ -55,28 +56,43 @@
     owner: "{{ ansible_user }}"
     mode: '0644'
   become: true
+  when: not k3s_active | default(false)
 
 - name: Write GitHub token to file
   ansible.builtin.copy:
     content: "{{ access_token }}"
     dest: "/home/{{ ansible_user }}/.github_token"
     mode: '0600'
+  when: not k3s_active | default(false)
 
 - name: Log in to GitHub
   ansible.builtin.shell: |
     set -o pipefail
     gh auth login --with-token < "/home/{{ ansible_user }}/.github_token"
+  changed_when: true
+  when: not k3s_active | default(false)
 
 - name: Read k3s manager join token
   ansible.builtin.slurp:
     src: /var/lib/rancher/k3s/server/node-token
   register: node_token_raw
   become: true
+  when: not k3s_active | default(false)
 
 - name: Set decoded join token as a fact
   ansible.builtin.set_fact:
     k3s_join_token: "{{ node_token_raw.content | b64decode | regex_replace('\n', '') }}"
+  when: not k3s_active | default(false)
 
 - name: Push K3s join token to GitHub Environment Secret
   ansible.builtin.shell: |
+    set -o pipefail
     echo "{{ k3s_join_token | trim }}" | gh secret set K3S_JOIN_TOKEN --env {{ github_env }} --repo {{ github_repo }}
+  changed_when: true
+  when: not k3s_active | default(false)
+
+- name: Remove GitHub token file
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/.github_token"
+    state: absent
+  when: not k3s_active | default(false)

--- a/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
+++ b/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
@@ -64,6 +64,7 @@
 
 - name: Log in to GitHub
   ansible.builtin.shell: |
+    set -o pipefail
     gh auth login --with-token < "/home/{{ ansible_user }}/.github_token"
 
 - name: Read k3s manager join token
@@ -73,7 +74,7 @@
   become: true
 
 - name: Set decoded join token as a fact
-  set_fact:
+  ansible.builtin.set_fact:
     k3s_join_token: "{{ node_token_raw.content | b64decode | regex_replace('\n', '') }}"
 
 - name: Push K3s join token to GitHub Environment Secret

--- a/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
+++ b/src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml
@@ -58,7 +58,7 @@
 
 - name: Write GitHub token to file
   ansible.builtin.copy:
-    content: "{{ github_token }}"
+    content: "{{ access_token }}"
     dest: "/home/{{ ansible_user }}/.github_token"
     mode: '0600'
 


### PR DESCRIPTION
This pull request introduces updates to the GitHub secrets management and Ansible configuration for the `helheim_cluster`. The changes primarily focus on replacing the use of `github_token` with `access_token` and improving the organization of environment-specific variables.

### Updates to secrets management:

* [`.github/workflows/cd-kubernetes-initialize.yml`](diffhunk://#diff-9e0b1332ad1498414505be699f60a085004d1ef74748172457a3c4d155bfafecL28-R29): Added `ACCESS_TOKEN` to the `TOKENS` secret configuration to support the updated authentication flow.

### Updates to Ansible configuration:

* [`src/ansible/inventories/group_vars/helheim_cluster.yml`](diffhunk://#diff-1c53efe9ab014c07a77b79980f44a1691cfe4e5eb12060c224ba1c6c3ebc44a2R2-R3): Added `github_env` and `github_repo` variables and included `access_token` in the configuration to align with the new secrets management approach. [[1]](diffhunk://#diff-1c53efe9ab014c07a77b79980f44a1691cfe4e5eb12060c224ba1c6c3ebc44a2R2-R3) [[2]](diffhunk://#diff-1c53efe9ab014c07a77b79980f44a1691cfe4e5eb12060c224ba1c6c3ebc44a2R21)
* [`src/ansible/roles/kubernetes_leader/tasks/install-k3s.yaml`](diffhunk://#diff-3b0e45f2d3eb69e77b26ccc558e06c7b5b43acb5f943330b27813272aec98f74L61-R61): Updated the task for writing the GitHub token to a file to use `access_token` instead of `github_token`.
* [`src/ansible/roles/kubernetes_leader/defaults/main.yml`](diffhunk://#diff-808d55f47f5eb814161c4fbf4ca29a2cc7b38ef85347c67af942b98208b80e2eL1-L4): Removed redundant `github_token`, `github_env`, and `github_repo` variables from the role defaults, as they are now defined elsewhere.