### PR TITLE
ci: implement kubernetes manifest lintin workflow

### DIFF
--- a/.github/workflows/lint-manifests.yml
+++ b/.github/workflows/lint-manifests.yml
@@ -1,0 +1,20 @@
+---
+name: Lint - Manifests
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - kubernetes/**/*.yaml
+    - kubernetes/**/*.yml
+
+jobs:
+  lint-yaml:
+    name: Validate YAML
+    uses: TheLionsRain/reusable-workflows/.github/workflows/lint-yaml.yml@lint-yaml-v1.0.0
+    with:
+      RUNS_ON: ubuntu-24.04
+      PYTHON_VERSION: 3.13
+      YAMLLINT_CONFIG_PATH: .yamllint
+      LINT_PATH: kubernetes/


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to lint Kubernetes manifest files, ensuring YAML files in the `kubernetes/` directory adhere to proper formatting and standards.

* [`.github/workflows/lint-manifests.yml`](diffhunk://#diff-896f200df3e9f30179d298d34ba7e6626cc8059729ccebf39ad3b572aece4689R1-R20): Added a new workflow named "Lint - Manifests" that triggers on pull requests to the `main` branch affecting YAML files in the `kubernetes/` directory. It uses a reusable workflow to validate YAML files with specified configurations, including `ubuntu-24.04` as the runner, Python 3.13, and a custom `.yamllint` configuration file.