### PR TITLE
feat: implement cert-manager manifests for bootstrapping

### DIFF
--- a/src/kubernetes/core/cert-manager/application.yml
+++ b/src/kubernetes/core/cert-manager/application.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  labels:
+    app: cert-manager
+spec:
+  destination:
+    namespace: cert-manager
+    server: https://kubernetes.default.svc
+  project: default
+  sources:
+  - chart: cert-manager
+    repoURL: https://charts.jetstack.io
+    targetRevision: v1.17.2
+    helm:
+      valueFiles:
+        - $values/src/kubernetes/cert-manager/values.yml
+  - repoURL: 'https://github.com/TheLionsRain/homelab-gitops.git'
+    targetRevision: HEAD
+    ref: values
+  - repoURL: 'https://github.com/TheLionsRain/homelab-gitops.git'
+    path: src/kubernetes/cert-manager/manifests
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true
+      - CreateNamespace=true

--- a/src/kubernetes/core/cert-manager/manifests/cluster-issuer.yml
+++ b/src/kubernetes/core/cert-manager/manifests/cluster-issuer.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cloudflare
+spec:
+  acme:
+    email: michiel.vanherreweghe@outlook.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: cluster-issuer-account-key
+    solvers:
+    - dns01:
+        cloudflare:
+          apiTokenSecretRef:
+            name: cloudflare-api-key
+            key: api-token

--- a/src/kubernetes/core/cert-manager/manifests/kustomization.yml
+++ b/src/kubernetes/core/cert-manager/manifests/kustomization.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cluster-issuer.yml

--- a/src/kubernetes/core/cert-manager/values.yml
+++ b/src/kubernetes/core/cert-manager/values.yml
@@ -1,0 +1,8 @@
+---
+crds:
+  enabled: true
+
+config:
+  apiVersion: controller.config.cert-manager.io/v1alpha1
+  kind: ControllerConfiguration
+  enableGatewayAPI: true


### PR DESCRIPTION
This pull request introduces the deployment of `cert-manager` in a Kubernetes cluster using ArgoCD and includes configurations for its setup and integration. The most important changes involve defining an ArgoCD application for `cert-manager`, creating a `ClusterIssuer` for Let's Encrypt with Cloudflare DNS, and adding supporting configuration files.

### ArgoCD Application for `cert-manager`:

* [`src/kubernetes/core/cert-manager/application.yml`](diffhunk://#diff-3e87d3311b21cd63d574b3250269a1a8afe6ba1b12f6c1cc95302552a02c7090R1-R35): Added an ArgoCD application definition for `cert-manager`, specifying the Helm chart source, a Git repository for additional manifests, and automated sync policies.

### `cert-manager` Configuration:

* [`src/kubernetes/core/cert-manager/values.yml`](diffhunk://#diff-c5ae0945651f9db0ac731181b215fb39ca0b23eb573c49da2a61e31a16dc1fa6R1-R8): Added a Helm values file enabling CRDs and configuring the `cert-manager` controller to support Gateway API.

### Let's Encrypt Integration:

* [`src/kubernetes/core/cert-manager/manifests/cluster-issuer.yml`](diffhunk://#diff-788f6543df7ace4a6b634f1efccc434d2c56ab548910c0851a704c29312a575eR1-R17): Created a `ClusterIssuer` resource for Let's Encrypt using Cloudflare DNS for DNS-01 challenges, including references to secret keys for authentication.

### Kustomize Support:

* [`src/kubernetes/core/cert-manager/manifests/kustomization.yml`](diffhunk://#diff-4370cba5e8de0f76f5e508a59965deef581a1ad3af897ab1be9e9ca5126f111cR1-R6): Added a Kustomize configuration to manage the `ClusterIssuer` manifest.