### PR TITLE
refactor: move from bicep to terraform

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -2,7 +2,7 @@
 name: CI - Terraform
 
 on:
-  push:
+  pull_request:
     branches:
     - main
     paths:

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -22,6 +22,7 @@ jobs:
       TERRAFORM_WORKING_DIRECTORY: src/terraform
       TERRAFORM_BACKEND: src/terraform/tfbackends/helheim.tfbackend
       TERRAFORM_VARFILE: src/terraform/tfvars/helheim.tfvars
+      TERRAFORM_PLAN_NAME: helheim.tfplan
       FILES_TO_TOKENIZE: src/terraform/tfvars/helheim.tfvars
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -20,10 +20,10 @@ jobs:
     with:
       ENVIRONMENT: helheim
       TERRAFORM_WORKING_DIRECTORY: src/terraform
-      TERRAFORM_BACKEND: src/terraform/tfbackends/helheim.tfbackend
-      TERRAFORM_VARFILE: src/terraform/tfvars/helheim.tfvars
+      TERRAFORM_BACKEND: tfbackends/helheim.tfbackend
+      TERRAFORM_VARFILE: tfvars/helheim.tfvars
       TERRAFORM_PLAN_NAME: helheim.tfplan
-      FILES_TO_TOKENIZE: src/terraform/tfvars/helheim.tfvars
+      FILES_TO_TOKENIZE: tfvars/helheim.tfvars
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/src/terraform/key_vault.tf
+++ b/src/terraform/key_vault.tf
@@ -1,0 +1,27 @@
+# Current
+data "azurerm_client_config" "current" {}
+
+# New Resources
+## Resource Group
+resource "azurerm_resource_group" "rg_kv" {
+  name     = var.key_vault_resource_group_name
+  location = var.location
+}
+
+## Key Vault
+resource "azurerm_key_vault" "kv" {
+  name                      = var.key_vault_name
+  location                  = var.location
+  resource_group_name       = azurerm_resource_group.rg_kv.name
+  sku_name                  = var.key_vault_sku
+  tenant_id                 = data.azurerm_client_config.current.tenant_id
+  enable_rbac_authorization = true
+  purge_protection_enabled  = var.key_vault_purge_protection
+}
+
+resource "azurerm_key_vault_secret" "secrets" {
+  for_each     = nonsensitive(var.key_vault_secrets)
+  name         = each.key
+  value        = var.key_vault_secrets[each.key]
+  key_vault_id = azurerm_key_vault.kv.id
+}

--- a/src/terraform/providers.tf
+++ b/src/terraform/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.29.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id = var.deployment_subscription_id
+  features {}
+}

--- a/src/terraform/tfbackends/helheim.tfbackend
+++ b/src/terraform/tfbackends/helheim.tfbackend
@@ -1,0 +1,6 @@
+subscription_id      = "2b22d58f-b265-48e2-8341-e0f2afc6610c"
+resource_group_name  = "rg-management-storage-ne"
+storage_account_name = "stterraformmgmttcrkne"
+container_name       = "c-tfstate-homelab-helheim"
+key                  = "helheim.tfstate"
+use_azuread_auth     = true

--- a/src/terraform/tfvars/helheim.tfvars
+++ b/src/terraform/tfvars/helheim.tfvars
@@ -1,0 +1,8 @@
+deployment_subscription_id    = "2b22d58f-b265-48e2-8341-e0f2afc6610c"
+location                      = "northeurope"
+key_vault_resource_group_name = "rg-homelab-helheim-kv-ne"
+key_vault_name                = "kv-homelab-helheim-ne"
+key_vault_sku                 = "standard"
+key_vault_secrets = {
+  "cloudflare-api-token" = "#{CLOUDFLARE_API_TOKEN}#"
+}

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -1,0 +1,47 @@
+# General Variables
+variable "deployment_subscription_id" {
+  description = "The ID of the subscription where the resources will be deployed."
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure region where the resources will be deployed."
+  type        = string
+}
+
+# Key Vault Variables
+## Key Vault Resource Group
+variable "key_vault_resource_group_name" {
+  description = "The name of the resource group where the Key Vault will be created."
+  type        = string
+}
+
+## Key Vault
+variable "key_vault_name" {
+  description = "The name of the Key Vault."
+  type        = string
+}
+
+variable "key_vault_sku" {
+  description = "The SKU of the Key Vault."
+  type        = string
+
+  validation {
+    condition     = contains(["standard", "premium"], lower(var.key_vault_sku))
+    error_message = "The Key Vault SKU must be either 'standard' or 'premium'."
+  }
+}
+
+variable "key_vault_purge_protection" {
+  description = "Enable purge protection for the Key Vault. Defaults to false."
+  type        = bool
+  default     = false
+}
+
+## Key Vault Secrets
+variable "key_vault_secrets" {
+  description = "A map of secrets to be stored in the Key Vault. Defaults to an empty object."
+  type        = map(string)
+  sensitive   = true
+  default     = {}
+}


### PR DESCRIPTION
This pull request introduces infrastructure as code (IaC) changes for deploying an Azure Key Vault and its associated resources using Terraform. The changes include defining the necessary variables, configuring the provider, creating the Key Vault and its secrets, and setting up the backend for Terraform state management.

### Key Vault Deployment

* Added a new resource group and Key Vault configuration in `src/terraform/key_vault.tf`, including support for RBAC authorization and purge protection. Secrets are dynamically created from a provided map (`key_vault_secrets`).

### Provider Configuration

* Configured the `azurerm` provider in `src/terraform/providers.tf` with a required version of `4.29.0` and subscription-specific settings.

### Terraform State Management

* Defined a backend configuration in `src/terraform/tfbackends/helheim.tfbackend` for storing the Terraform state in an Azure Storage account with Azure AD authentication.

### Variable Definitions

* Introduced variables in `src/terraform/variables.tf` for subscription ID, location, Key Vault details (name, SKU, purge protection), and secrets. Validation was added for the Key Vault SKU to ensure it is either "standard" or "premium."

### Environment-Specific Configuration

* Added environment-specific values in `src/terraform/tfvars/helheim.tfvars`, including subscription ID, location, resource group name, Key Vault name, SKU, and secrets.