### PR TITLE
feat: implement backup storage account

### DIFF
--- a/src/terraform/backup_storage_account.tf
+++ b/src/terraform/backup_storage_account.tf
@@ -28,6 +28,6 @@ resource "azurerm_storage_container" "container_longhorn" {
   name               = var.longhorn_container_name
   storage_account_id = azurerm_storage_account.st_backup.id
   depends_on = [
-    azurerm_role_assignment.roles
+    azurerm_role_assignment.roles_st_backup
   ]
 }

--- a/src/terraform/backup_storage_account.tf
+++ b/src/terraform/backup_storage_account.tf
@@ -16,7 +16,7 @@ resource "azurerm_storage_account" "st_backup" {
 }
 
 ## Role Assignments
-resource "azurerm_role_assignment" "roles" {
+resource "azurerm_role_assignment" "roles_st_backup" {
   for_each             = { for role in var.backup_storage_account_role_assignments : "${role.principal_id}-${role.role_definition_name}" => role }
   scope                = azurerm_storage_account.st_backup.id
   role_definition_name = each.value.role_definition_name

--- a/src/terraform/backup_storage_account.tf
+++ b/src/terraform/backup_storage_account.tf
@@ -1,0 +1,33 @@
+# New Resources
+## Resource Group
+resource "azurerm_resource_group" "rg_st" {
+  name     = var.storage_account_resource_group_name
+  location = var.location
+}
+
+## Storage Account
+resource "azurerm_storage_account" "st_backup" {
+  name                     = var.backup_storage_account_name
+  resource_group_name      = azurerm_resource_group.rg_st.name
+  location                 = azurerm_resource_group.rg_st.location
+  account_kind             = var.backup_storage_account_kind
+  account_tier             = var.backup_storage_account_tier
+  account_replication_type = var.backup_storage_account_replication_type
+}
+
+## Role Assignments
+resource "azurerm_role_assignment" "roles" {
+  for_each             = { for role in var.backup_storage_account_role_assignments : "${role.principal_id}-${role.role_definition_name}" => role }
+  scope                = azurerm_storage_account.st_backup.id
+  role_definition_name = each.value.role_definition_name
+  principal_id         = each.value.principal_id
+}
+
+## Longhorn Container
+resource "azurerm_storage_container" "container_longhorn" {
+  name               = var.longhorn_container_name
+  storage_account_id = azurerm_storage_account.st_backup.id
+  depends_on = [
+    azurerm_role_assignment.roles
+  ]
+}

--- a/src/terraform/key_vault.tf
+++ b/src/terraform/key_vault.tf
@@ -20,7 +20,7 @@ resource "azurerm_key_vault" "kv" {
 }
 
 ## Role Assignments
-resource "azurerm_role_assignment" "roles" {
+resource "azurerm_role_assignment" "roles_kv" {
   for_each             = { for role in var.key_vault_role_assignments : "${role.principal_id}-${role.role_definition_name}" => role }
   scope                = azurerm_key_vault.kv.id
   role_definition_name = each.value.role_definition_name

--- a/src/terraform/key_vault.tf
+++ b/src/terraform/key_vault.tf
@@ -34,6 +34,6 @@ resource "azurerm_key_vault_secret" "secrets" {
   value        = var.key_vault_secrets[each.key]
   key_vault_id = azurerm_key_vault.kv.id
   depends_on = [
-    azurerm_role_assignment.roles
+    azurerm_role_assignment.roles_kv
   ]
 }

--- a/src/terraform/tfvars/helheim.tfvars
+++ b/src/terraform/tfvars/helheim.tfvars
@@ -48,3 +48,6 @@ backup_storage_account_role_assignments = [
     principal_id         = "616f3b54-c44f-4758-bc09-96a8247cb324" # app-k8s-helheim-longhorn-ne
   }
 ]
+
+## Storage Account - Backup - Longhorn Container
+longhorn_container_name = "c-backup"

--- a/src/terraform/tfvars/helheim.tfvars
+++ b/src/terraform/tfvars/helheim.tfvars
@@ -1,18 +1,50 @@
+# General Variables
 deployment_subscription_id    = "2b22d58f-b265-48e2-8341-e0f2afc6610c"
 location                      = "northeurope"
+
+# Key Vault Variables
+## Key Vault Resource Group
 key_vault_resource_group_name = "rg-homelab-helheim-kv-ne"
+
+## Key Vault
 key_vault_name                = "kv-homelab-helheim-ne"
 key_vault_sku                 = "standard"
+
+## Key Vault Role Assignments
 key_vault_role_assignments = [
   {
     role_definition_name = "Key Vault Secrets Administrator"
-    principal_id         = "372dc01a-ddc4-4de0-b37d-472ffe31e28b" # sp-gh-homelab
+    principal_id         = "a176ebb0-c01d-473a-8205-2370942a9e9e" # sp-gh-homelab
   },
   {
     role_definition_name = "Key Vault Secrets User"
-    principal_id         = "09efc1fe-6ac9-4ada-8eb8-7d9d3c758c1c" # app-k8s-helheim-external-secrets-ne
+    principal_id         = "27274c88-7182-4afa-8bac-b7e7db0ba915" # app-k8s-helheim-external-secrets-ne
   }
 ]
+
+## Key Vault Secrets
 key_vault_secrets = {
   "cloudflare-api-token" = "#{CLOUDFLARE_API_TOKEN}#"
 }
+
+# Storage Account Variables
+## Storage Account Resource Group
+storage_account_resource_group_name = "rg-homelab-helheim-storage-ne"
+
+## Storage Account - Backup
+backup_storage_account_name = "sthomelabhelheimbackupne"
+backup_storage_account_kind = "BlobStorage"
+backup_storage_account_tier = "Standard"
+backup_storage_account_replication_type = "LRS"
+
+## Storage Account - Backup - Role Assignments
+backup_storage_account_role_assignments = [
+  {
+    role_definition_name = "Storage Account Contributor"
+    principal_id         = "a176ebb0-c01d-473a-8205-2370942a9e9e" # sp-gh-homelab
+  },
+  {
+    role_definition_name = "Storage Blob Data Contributor"
+    principal_id         = "616f3b54-c44f-4758-bc09-96a8247cb324" # app-k8s-helheim-longhorn-ne
+  }
+]

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -55,3 +55,70 @@ variable "key_vault_secrets" {
   sensitive   = true
   default     = {}
 }
+
+# Storage Account Variables
+## Storage Account Resource Group
+variable "storage_account_resource_group_name" {
+  description = "The name of the resource group where the storage account will be created."
+  type        = string
+}
+
+## Storage Account - Backup
+variable "backup_storage_account_name" {
+  description = "The name of the storage account for backups."
+  type        = string
+}
+
+variable "backup_storage_account_kind" {
+  description = "The kind of the storage account."
+  type        = string
+
+  validation {
+    condition     = contains(["BlobStorage", "BlockBlobStorage", "FileStorage", "Storage", "StorageV2"], var.backup_storage_account_kind)
+    error_message = "The Storage Account kind must be BlobStorage, BlockBlobStorage, FileStorage, Storage or StorageV2."
+  }
+}
+
+variable "backup_storage_account_tier" {
+  description = "The performance tier of the storage account."
+  type        = string
+
+  validation {
+    condition = (
+      contains(["Standard", "Premium"], var.backup_storage_account_tier) &&
+      !contains(["BlockBlobStorage", "FileStorage"], var.backup_storage_account_kind) ||
+      (contains(["BlockBlobStorage", "FileStorage"], var.backup_storage_account_kind) && var.backup_storage_account_tier == "Premium")
+    )
+
+    error_message = <<EOT
+      The performance tier must be either 'Standard' or 'Premium'.
+      When the storage account kind is 'BlockBlobStorage' or 'FileStorage', the tier must be 'Premium'.
+      EOT
+  }
+}
+
+variable "backup_storage_account_replication_type" {
+  description = "The replication type of the storage account."
+  type        = string
+
+  validation {
+    condition     = contains(["LRS", "GRS", "RAGRS", "ZRS", "GZRS", "RAGZRS"], var.backup_storage_account_replication_type)
+    error_message = "The Storage Account replication type LRS, GRS, RAGRS, ZRS, GZRS or RAGZRS."
+  }
+}
+
+## Storage Account - Backup - Role Assignments
+variable "backup_storage_account_role_assignments" {
+  description = "A list of role assignments for the storage account. Defaults to an empty list."
+  type = list(object({
+    role_definition_name = string
+    principal_id         = string
+  }))
+  default = []
+}
+
+## Storage Account - Backup - Longhorn Container
+variable "longhorn_container_name" {
+  description = "The name of the Longhorn container."
+  type        = string
+}


### PR DESCRIPTION
This pull request introduces new Terraform configurations to provision and manage an Azure storage account for backups and its associated resources. It also updates related variables and configurations to support these changes. Below are the most important changes grouped by theme:

### New Azure Resources for Backup Storage
* Added a new resource group, storage account, role assignments, and a container for Longhorn backups in `src/terraform/backup_storage_account.tf`. These resources are parameterized for flexibility using variables.

### Updates to Variable Definitions
* Introduced new variables in `src/terraform/variables.tf` to support the backup storage account, including variables for resource group name, storage account name, kind, tier, replication type, role assignments, and Longhorn container name. These variables include validation rules for acceptable values.

### Updates to Environment-Specific Configuration
* Updated `src/terraform/tfvars/helheim.tfvars` to define values for the new storage account variables, including resource group name, account name, kind, tier, replication type, and role assignments. Also added configurations for Key Vault secrets. [[1]](diffhunk://#diff-7dc8c4a415d7f68e325e5bfb3642cd3bea80df6c9bd04fd23df5359a62761c40R1-R13) [[2]](diffhunk://#diff-7dc8c4a415d7f68e325e5bfb3642cd3bea80df6c9bd04fd23df5359a62761c40R24-R50)